### PR TITLE
Update npm CI to use the public npm registry

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,7 +69,7 @@ stages:
           - task: NodeTool@0
             inputs: { versionSpec: '22.x' }
 
-          - script: npm ci --cache "$(Pipeline.Workspace)/.npm" --prefer-offline
+          - script: npm ci --registry=https://registry.npmjs.org/
             displayName: 'npm ci'
 
           - script: |


### PR DESCRIPTION
```
### Description

This pull request updates the npm CI command in the pipeline to use the public npm registry. This ensures compatibility and resolves issues potentially caused by accessing private or alternate registries during CI builds.

### Changes

- Modified the CI pipeline to explicitly specify the use of the public npm registry for `npm ci`.

### Checklist

- [ ] Tests have been updated or added if necessary.
- [ ] Documentation has been updated or added if necessary.
```